### PR TITLE
reformat for get_masterlist, not yet finished

### DIFF
--- a/get_masterlist.py
+++ b/get_masterlist.py
@@ -1,14 +1,17 @@
 import os
 
-def crt_master(dirs):
-    masterlist = os.path.join(os.getcwd, "masterlist.txt")
+def crt_list(dirs, cwd):
     for d in dirs:
-        d = os.path.join(os.getcwd, d)
+        d = os.path.join(cwd, d)
         for subdir, _, files in d:
             for f in files:
                 with open(masterlist, 'a') as master:
                     master.write(os.path.join(subdir, f) + "\n")
 
 if __name__ == "__main__":
-    crt_master(["train", "validate", "test"])
+    cwd = os.getcwd()
+    train_list = os.path.join(cwd, "trains.txt")
+    valid_list = os.path.join(cwd, "valids.txt")
+    test_list = os.path.join(cwd, "tests.txt")
+    crt_list(["train", "validate", "test"], cwd)
     print("done")


### PR DESCRIPTION
Basic redesign for get_masterlist in order to generate three separate master lists. As of now, the crt_list (previously crt_masterlist) function is more or less unaltered. Will update soon.